### PR TITLE
make current unit tests pass and phpcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
   "require-dev": {
     "phpunit/phpunit": "^6.1",
     "squizlabs/PHP_CodeSniffer": "^2.8",
-    "mockery/mockery": "^0.9.9"
+    "mockery/mockery": "^0.9.9",
+    "mikey179/vfsStream": "^1.6"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "04856959af9005ae6fb38ad8003baba3",
+    "content-hash": "136dac82294555c2c2379aa11db6d53a",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2165,6 +2165,52 @@
                 "test"
             ],
             "time": "2015-05-11T14:41:42+00:00"
+        },
+        {
+            "name": "mikey179/vfsStream",
+            "version": "v1.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikey179/vfsStream.git",
+                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2017-08-01T08:02:14+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit
     backupGlobals="false"
     colors="true"
-    bootstrap="example/bootstrap.php"
+    bootstrap="vendor/autoload.php"
 >
 
     <testsuites>
@@ -14,6 +14,9 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
+            <exclude>
+                <directory suffix=".php">./src/FieldType/Relationship/GeneratorTemplate</directory>
+            </exclude>
         </whitelist>
     </filter>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit
     backupGlobals="false"
     colors="true"
-    bootstrap="vendor/autoload.php"
+    bootstrap="example/bootstrap.php"
 >
 
     <testsuites>

--- a/src/SectionField/SectionFieldInterface/SectionManager.php
+++ b/src/SectionField/SectionFieldInterface/SectionManager.php
@@ -9,7 +9,7 @@ interface SectionManager
     public function create(Section $entity): Section;
     public function read(Id $id): Section;
     public function readAll(): array;
-    public function update(): void;
+    public function update(Section $entity): void;
     public function delete(Section $entity): void;
     public function createByConfig(SectionConfig $sectionConfig): Section;
     public function updateByConfig(SectionConfig $sectionConfig, Section $section): Section;

--- a/src/SectionField/Service/DoctrineSectionManager.php
+++ b/src/SectionField/Service/DoctrineSectionManager.php
@@ -75,8 +75,9 @@ class DoctrineSectionManager implements SectionManager
         return $sections;
     }
 
-    public function update(): void
+    public function update(Section $entity): void
     {
+        $this->entityManager->persist($entity);
         $this->entityManager->flush();
     }
 

--- a/test/unit/Command/CreateApplicationCommandTest.php
+++ b/test/unit/Command/CreateApplicationCommandTest.php
@@ -5,6 +5,7 @@ namespace Tardigrades\Command;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -28,8 +29,13 @@ final class CreateApplicationCommandTest extends TestCase
     /** @var Application */
     private $application;
 
+    /** @var vfsStream */
+    private $file;
+
     public function setUp()
     {
+        vfsStream::setup('home');
+        $this->file = vfsStream::url('home/some-config-file.yml');
         $this->applicationManager = Mockery::mock(ApplicationManager::class);
         $this->createApplicationCommand = new CreateApplicationCommand($this->applicationManager);
         $this->application = new Application();
@@ -43,6 +49,15 @@ final class CreateApplicationCommandTest extends TestCase
      */
     public function it_should_create_an_application_based_on_config()
     {
+        $yml = <<<YML
+application:
+    name: foo
+    handle: bar
+    languages: []
+YML;
+
+        file_put_contents($this->file, $yml);
+
         $command = $this->application->find('sf:create-application');
         $commandTester = new CommandTester($command);
 
@@ -53,7 +68,7 @@ final class CreateApplicationCommandTest extends TestCase
         $commandTester->execute(
             [
                 'command' => $command->getName(),
-                'config' => 'some-application-config-file.yml'
+                'config' => $this->file
             ]
         );
 
@@ -70,13 +85,19 @@ final class CreateApplicationCommandTest extends TestCase
      */
     public function it_should_fail_with_invalid_config()
     {
+        $yml = <<<YML
+invalid:
+    yml:
+YML;
+
+        file_put_contents($this->file, $yml);
         $command = $this->application->find('sf:create-application');
         $commandTester = new CommandTester($command);
 
         $commandTester->execute(
             [
                 'command' => $command->getName(),
-                'config' => 'some-erroneous-application-config-file.yml'
+                'config' => $this->file
             ]
         );
 

--- a/test/unit/Command/DeleteFieldTypeCommandTest.php
+++ b/test/unit/Command/DeleteFieldTypeCommandTest.php
@@ -91,4 +91,39 @@ final class DeleteFieldTypeCommandTest extends TestCase
             $commandTester->getDisplay()
         );
     }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_not_delete_field_type_with_id_1_when_cancelled()
+    {
+        $command = $this->application->find('sf:delete-field');
+        $commandTester = new CommandTester($command);
+
+        $fields = $this->givenAnArrayOfFieldTypes();
+
+        $this->fieldTypeManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($fields);
+
+        $this->fieldTypeManager
+            ->shouldReceive('read')
+            ->once()
+            ->andReturn($fields[0]);
+
+        $this->fieldTypeManager
+            ->shouldReceive('delete')
+            ->never();
+
+        $commandTester->setInputs([1, 'n']);
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/Cancelled, nothing deleted./',
+            $commandTester->getDisplay()
+        );
+    }
 }

--- a/test/unit/Command/InstallFieldTypeCommandTest.php
+++ b/test/unit/Command/InstallFieldTypeCommandTest.php
@@ -58,7 +58,8 @@ final class InstallFieldTypeCommandTest extends TestCase
         $this->fieldTypeManager
             ->shouldReceive('createWithFullyQualifiedClassName')
             ->once()
-            ->andReturn((new FieldType())
+            ->andReturn(
+                (new FieldType())
                 ->setType('TextArea')
                 ->setFullyQualifiedClassName('Some\\Fully\\Qualified\\Class\\Name')
                 ->setCreated(new \DateTime())

--- a/test/unit/Command/ListApplicationCommandTest.php
+++ b/test/unit/Command/ListApplicationCommandTest.php
@@ -16,6 +16,7 @@ use Tardigrades\Entity\Application as ApplicationEntity;
 /**
  * @coversDefaultClass Tardigrades\Command\ListApplicationCommand
  * @covers ::<private>
+ * @covers ::<protected>
  * @covers ::__construct
  */
 final class ListApplicationCommandTest extends TestCase
@@ -90,6 +91,56 @@ final class ListApplicationCommandTest extends TestCase
 
         $this->assertRegExp(
             '/All installed Applications/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/someName/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Some Name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Section Name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Another section name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/nl_NL/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/en_EN/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/someOtherName/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Some Other Name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Section Super Name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Another Super section name/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/ListFieldCommandTest.php
+++ b/test/unit/Command/ListFieldCommandTest.php
@@ -5,6 +5,7 @@ namespace Tardigrades\Command;
 
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -24,27 +25,60 @@ final class ListFieldCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @var FieldManager
-     */
+    /** @var FieldManager */
     private $fieldManager;
 
-    /**
-     * @var ListFieldCommand
-     */
+    /** @var ListFieldCommand */
     private $listFieldCommand;
 
-    /**
-     * @var Application
-     */
+    /** @var Application */
     private $application;
+
+    /** @var vfsStream */
+    private $file;
 
     public function setUp()
     {
+        vfsStream::setup('home');
+        $this->file = vfsStream::url('home/some-config-file.yml');
         $this->fieldManager = Mockery::mock(FieldManager::class);
         $this->listFieldCommand = new ListFieldCommand($this->fieldManager);
         $this->application = new Application();
         $this->application->add($this->listFieldCommand);
+    }
+
+    /**
+     * @test
+     * @covers ::configure
+     * @covers ::execute
+     */
+    public function it_should_list_fields()
+    {
+        $yml = <<<YML
+field:
+    name: foo
+    handle: bar
+    label: [ label ]
+YML;
+
+        file_put_contents($this->file, $yml);
+
+        $command = $this->application->find('sf:list-field');
+        $commandTester = new CommandTester($command);
+
+        $fields = $this->givenAnArrayOfFields();
+
+        $this->fieldManager
+            ->shouldReceive('readAll')
+            ->once()
+            ->andReturn($fields);
+
+        $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/All installed Fields/',
+            $commandTester->getDisplay()
+        );
     }
 
     private function givenAnArrayOfFields()
@@ -57,7 +91,7 @@ final class ListFieldCommandTest extends TestCase
                     (new FieldType())
                         ->setName('TextInput')
                 )
-                ->setConfig(Yaml::parse(file_get_contents('some-field-config-file.yml')))
+                ->setConfig(Yaml::parse(file_get_contents($this->file)))
                 ->addFieldTranslation(
                     (new FieldTranslation())
                         ->setName('Some field name')
@@ -89,7 +123,7 @@ final class ListFieldCommandTest extends TestCase
                     (new FieldType())
                         ->setName('TextArea')
                 )
-                ->setConfig(Yaml::parse(file_get_contents('some-field-config-file.yml')))
+                ->setConfig(Yaml::parse(file_get_contents($this->file)))
                 ->addFieldTranslation(
                     (new FieldTranslation())
                         ->setName('Some other field name')
@@ -121,7 +155,7 @@ final class ListFieldCommandTest extends TestCase
                     (new FieldType())
                         ->setName('TextArea')
                 )
-                ->setConfig(Yaml::parse(file_get_contents('some-field-config-file.yml')))
+                ->setConfig(Yaml::parse(file_get_contents($this->file)))
                 ->addFieldTranslation(
                     (new FieldTranslation())
                         ->setName('And another field name')
@@ -147,30 +181,5 @@ final class ListFieldCommandTest extends TestCase
                 ->setCreated(new \DateTime())
                 ->setUpdated(new \DateTime()),
         ];
-    }
-
-    /**
-     * @test
-     * @covers ::configure
-     * @covers ::execute
-     */
-    public function it_should_list_fields()
-    {
-        $command = $this->application->find('sf:list-field');
-        $commandTester = new CommandTester($command);
-
-        $fields = $this->givenAnArrayOfFields();
-
-        $this->fieldManager
-            ->shouldReceive('readAll')
-            ->once()
-            ->andReturn($fields);
-
-        $commandTester->execute(['command' => $command->getName()]);
-
-        $this->assertRegExp(
-            '/All installed Fields/',
-            $commandTester->getDisplay()
-        );
     }
 }

--- a/test/unit/Command/ListFieldCommandTest.php
+++ b/test/unit/Command/ListFieldCommandTest.php
@@ -19,6 +19,7 @@ use Tardigrades\SectionField\SectionFieldInterface\FieldManager;
 /**
  * @coversDefaultClass Tardigrades\Command\ListFieldCommand
  * @covers ::<private>
+ * @covers ::<protected>
  * @covers ::__construct
  */
 final class ListFieldCommandTest extends TestCase
@@ -74,6 +75,81 @@ YML;
             ->andReturn($fields);
 
         $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/en_EN Some field name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/nl_NL Een veldnaam/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/en_EN Some other field name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/nl_NL Een andere veldnaam/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/en_EN And another field name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/nl_NL En nog een veldnaam/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/en_EN Dit is een label/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/nl_NL Dit is een label/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/andAnotherName/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/TextInput/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/TextArea/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/name:foo/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/handle:bar/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/label:/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/-label/',
+            $commandTester->getDisplay()
+        );
 
         $this->assertRegExp(
             '/All installed Fields/',

--- a/test/unit/Command/ListFieldTypeCommandTest.php
+++ b/test/unit/Command/ListFieldTypeCommandTest.php
@@ -13,6 +13,7 @@ use Tardigrades\SectionField\SectionFieldInterface\FieldTypeManager;
 /**
  * @coversDefaultClass Tardigrades\Command\ListFieldTypeCommand
  * @covers ::<private>
+ * @covers ::<protected>
  * @covers ::__construct
  */
 final class ListFieldTypeCommandTest extends TestCase
@@ -76,6 +77,26 @@ final class ListFieldTypeCommandTest extends TestCase
             ->andReturn($fieldTypes);
 
         $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/TextArea/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/TextInput/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Super\\\\Qualified/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Amazing\\\\Input/',
+            $commandTester->getDisplay()
+        );
 
         $this->assertRegExp(
             '/All installed FieldTypes/',

--- a/test/unit/Command/ListLanguageCommandTest.php
+++ b/test/unit/Command/ListLanguageCommandTest.php
@@ -14,6 +14,7 @@ use Tardigrades\Entity\Application as ApplicationEntity;
 /**
  * @coversDefaultClass Tardigrades\Command\ListLanguageCommand
  * @covers ::<private>
+ * @covers ::<protected>
  * @covers ::__construct
  */
 final class ListLanguageCommandTest extends TestCase
@@ -98,6 +99,36 @@ final class ListLanguageCommandTest extends TestCase
 
         $this->assertRegExp(
             '/All installed languages/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/nl_NL/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/en_EN/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Application name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Another application name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Again, a name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Fffff, name/',
             $commandTester->getDisplay()
         );
     }

--- a/test/unit/Command/ListSectionCommandTest.php
+++ b/test/unit/Command/ListSectionCommandTest.php
@@ -15,6 +15,7 @@ use Tardigrades\SectionField\SectionFieldInterface\SectionManager;
 /**
  * @coversDefaultClass Tardigrades\Command\ListSectionCommand
  * @covers ::<private>
+ * @covers ::<protected>
  * @covers ::__construct
  */
 final class ListSectionCommandTest extends TestCase
@@ -70,6 +71,60 @@ YML;
             ->andReturn($languages);
 
         $commandTester->execute(['command' => $command->getName()]);
+
+        $this->assertRegExp(
+            '/Some name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/someHandle/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/name:foo/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/handle:bar/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/fields:/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/default:Default/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            "/namespace:My\\\\Namespace/",
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/Some other name/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/someOtherHandle/',
+            $commandTester->getDisplay()
+        );
+        $this->assertRegExp(
+            '/All installed Sections/',
+            $commandTester->getDisplay()
+        );
+
+        $this->assertRegExp(
+            '/All installed Sections/',
+            $commandTester->getDisplay()
+        );
 
         $this->assertRegExp(
             '/All installed Sections/',

--- a/test/unit/Command/UpdateFieldTypeCommandTest.php
+++ b/test/unit/Command/UpdateFieldTypeCommandTest.php
@@ -98,4 +98,3 @@ final class UpdateFieldTypeCommandTest extends TestCase
         );
     }
 }
-

--- a/test/unit/Entity/SectionTest.php
+++ b/test/unit/Entity/SectionTest.php
@@ -168,9 +168,11 @@ final class SectionTest extends TestCase
         $config = [
             'section' => [
                 'name' => 'I have a field name',
+                'handle' => 'handle',
                 'fields' => ['these', 'are', 'fields'],
                 'slug' => ['these'],
-                'default' => 'these'
+                'default' => 'these',
+                'namespace' => 'My\Namespace'
             ]
         ];
 
@@ -188,9 +190,11 @@ final class SectionTest extends TestCase
         $config = [
             'section' => [
                 'name' => 'I have a field name',
+                'handle' => 'handle',
                 'fields' => ['these', 'are', 'fields'],
                 'slug' => ['these'],
-                'default' => 'these'
+                'default' => 'these',
+                'namespace' => 'My\Namespace'
             ]
         ];
 

--- a/test/unit/SectionField/Service/ApplicationManagerTest.php
+++ b/test/unit/SectionField/Service/ApplicationManagerTest.php
@@ -197,4 +197,3 @@ final class ApplicationManagerTest extends TestCase
         $this->applicationManager->delete($application);
     }
 }
-

--- a/test/unit/SectionField/Service/FieldManagerTest.php
+++ b/test/unit/SectionField/Service/FieldManagerTest.php
@@ -369,4 +369,3 @@ final class FieldManagerTest extends TestCase
         return $field;
     }
 }
-

--- a/test/unit/SectionField/Service/FieldTypeManagerTest.php
+++ b/test/unit/SectionField/Service/FieldTypeManagerTest.php
@@ -190,7 +190,9 @@ final class FieldTypeManagerTest extends TestCase
      */
     public function it_should_create_with_fully_qualified_class_name()
     {
-        $fullyQualifiedClassName = FullyQualifiedClassName::create('There\\Are\\ClassNames\\That\\Are\\Fully\\Qualified');
+        $fullyQualifiedClassName = FullyQualifiedClassName::create(
+            'There\\Are\\ClassNames\\That\\Are\\Fully\\Qualified'
+        );
 
         $fieldType = new FieldType();
         $fieldType->setType($fullyQualifiedClassName->getClassName());

--- a/test/unit/SectionField/Service/LanguageManagerTest.php
+++ b/test/unit/SectionField/Service/LanguageManagerTest.php
@@ -225,4 +225,3 @@ final class LanguageManagerTest extends TestCase
         $this->assertEquals($language->getI18n(), $returnedLanguage->getI18n());
     }
 }
-

--- a/test/unit/SectionField/Service/SectionManagerTest.php
+++ b/test/unit/SectionField/Service/SectionManagerTest.php
@@ -180,9 +180,7 @@ final class SectionManagerTest extends TestCase
         $this->entityManager->shouldReceive('persist')->once()->with($section);
         $this->entityManager->shouldReceive('flush')->once();
 
-        $receive = $this->sectionManager->update($section);
-
-        $this->assertSame($receive, $section);
+        $this->sectionManager->update($section);
     }
 
     /**
@@ -207,13 +205,15 @@ final class SectionManagerTest extends TestCase
         $sectionConfig = SectionConfig::create([
             'section' => [
                 'name' => 'Super Section',
+                'handle' => 'superSection',
                 'fields' => [
                     'title',
                     'body',
                     'created'
                 ],
                 'slug' => ['title'],
-                'default' => 'title'
+                'default' => 'title',
+                'namespace' => 'My\Namespace'
             ]
         ]);
 
@@ -246,13 +246,15 @@ final class SectionManagerTest extends TestCase
         $sectionConfig = SectionConfig::create([
             'section' => [
                 'name' => 'Super Section',
+                'handle' => 'superSection',
                 'fields' => [
                     'title',
                     'body',
                     'created'
                 ],
                 'slug' => ['title'],
-                'default' => 'title'
+                'default' => 'title',
+                'namespace' => 'My\Namespace'
             ]
         ]);
 


### PR DESCRIPTION
With this PR I mocked the filesystem using vfsStream. The tests run now with mocked config files.
I moved private methods to be below the public methods of the test files I touched.
All current tests pass. Coverage of Commands folder is complete. 
